### PR TITLE
ci: add CLA gate

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read # read-only since signatures are stored in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          owner: nxm-rs
+          repositories: "pm,cla-signatures"
+
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          path-to-signatures: 'pm/cla.json'
+          path-to-document: 'https://github.com/nxm-rs/pm/blob/master/CLA.md'
+          # branch should not be protected
+          branch: 'main'
+          remote-organization-name: 'nxm-rs'
+          remote-repository-name: 'cla-signatures'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,24 @@
+# Nexum Contributor License Agreement
+
+Thank you for your interest in contributing to open source software projects (“Projects”) made available by Nexum Labs LLC, A SERIES OF OTOCO DE LLC. This Contributor License Agreement (“Agreement”) sets out the terms governing any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that you submit or have submitted, in any form and in any manner, to Nexum in respect of any of the Projects (collectively “Contributions”). If you have any questions respecting this Agreement, please contact legal@nxm.rs.
+
+You agree that the following terms apply to all of your past, present and future Contributions. Except for the licenses granted in this Agreement, you retain all of your right, title and interest in and to your Contributions.
+
+**Copyright License**. You hereby grant, and agree to grant, to Nexum a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, transferable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and such derivative works, with the right to sublicense the foregoing rights through multiple tiers of sublicensees.
+
+**Patent License**. You hereby grant, and agree to grant, to Nexum a non-exclusive, perpetual, irrevocable, worldwide, fully-paid, royalty-free, transferable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contributions alone or by combination of your Contributions with the Project to which such Contributions were submitted, with the right to sublicense the foregoing rights through multiple tiers of sublicensees.
+
+**Moral Rights**. To the fullest extent permitted under applicable law, you hereby waive, and agree not to assert, all of your “moral rights” in or relating to your Contributions for the benefit of Nexum, its assigns, and their respective direct and indirect sublicensees.
+
+**Third Party Content/Rights**. If your Contribution includes or is based on any source code, object code, bug fixes, configuration changes, tools, specifications, documentation, data, materials, feedback, information or other works of authorship that were not authored by you (“Third Party Content”) or if you are aware of any third party intellectual property or proprietary rights associated with your Contribution (“Third Party Rights”), then you agree to include with the submission of your Contribution full details respecting such Third Party Content and Third Party Rights.
+
+**Representations**. You represent that, other than the Third Party Content and Third Party Rights identified by you in accordance with this Agreement, you are the sole author of your Contributions and are legally entitled to grant the foregoing licenses and waivers in respect of your Contributions. If your Contributions were created in the course of your employment with your past or present employer(s), you represent that such employer(s) has authorized you to make your Contributions on behalf of such employer(s) or such employer(s) has waived all of their right, title or interest in or to your Contributions.
+
+**Disclaimer**. To the fullest extent permitted under applicable law, your Contributions are provided on an "as-is" basis, without any warranties or conditions, express or implied, including, without limitation, any implied warranties or conditions of non-infringement, merchantability or fitness for a particular purpose. You are not required to provide support for your Contributions, except to the extent you desire to provide support.
+
+**No Obligation**. You acknowledge that Nexum is under no obligation to use or incorporate your Contributions into any of the Projects. The decision to use or incorporate your Contributions into any of the Projects will be made at the sole discretion of Nexum or its authorized delegates.
+
+**Disputes**. This Agreement shall be governed by and construed in accordance with the laws of the State of Delaware, United States of America, without giving effect to its principles or rules regarding conflicts of laws, other than such principles directing application of Delaware law. The parties hereby submit to venue in, and jurisdiction of the courts located in Delaware, Delaware for purposes relating to this Agreement. In the event that any of the provisions of this Agreement shall be held by a court or other tribunal of competent jurisdiction to be unenforceable, the remaining portions hereof shall remain in full force and effect.
+
+**Assignment**. You agree that Nexum may assign this Agreement, and all of its rights, obligations and licenses hereunder.
+


### PR DESCRIPTION
## Summary

Adds the CLA workflow to align this repo with the rest of the branded set.

Files added:
- \`CLA.md\` — Nexum standard contributor agreement, copied verbatim from \`nxm-rs/nexum/CLA.md\`
- \`.github/workflows/cla.yml\` — \`contributor-assistant/github-action\` gate that writes signatures to \`nxm-rs/cla-signatures\` under \`pm/cla.json\`

Both actions are SHA-pinned per the org-wide supply-chain defence pass:
- \`actions/create-github-app-token@bcd2ba49…\` (v3.2.0)
- \`contributor-assistant/github-action@ca4a40a7…\` (v2.6.1)

## App installation

The \`nexum-cla-bot\` GitHub App is already installed on the nxm-rs org with \`repository_selection: "all"\`, so this repo is covered automatically. The org-level secrets \`CLA_APP_ID\` and \`CLA_APP_PRIVATE_KEY\` are inherited the same way they are for nexum/vertex/nectar/keycard/apdu.

## Test plan

- [ ] After merge, open a fresh PR and confirm the CLA Assistant check fires and either reports "CLA signed" (for me) or prompts to sign.
- [ ] Confirm \`pm/cla.json\` gets created in \`nxm-rs/cla-signatures\` on first non-pre-existing signer.